### PR TITLE
Support full paths in --config / -c option

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,7 +55,13 @@ _.each(args, function(value, key, list) {
 
 var config_path;
 if (args['config']) {
-    config_path = path.join(process.cwd(), args['config'])
+    if (args['config'].startsWith("/")) {
+        // set config_path to the config arg directly when it is a full path, beginning with a /
+        config_path = args['config'];
+    } else {
+        // otherwise set config_path to combined current working directory and the config arg
+        config_path = path.join(process.cwd(), args['config'])
+    }
 } else {
     config_path = path.join(process.env.HOME, '.config/slack-keep-presence')
 }
@@ -64,7 +70,7 @@ fs.readFile(config_path, 'utf8', function(err, data) {
     var config;
     if (err) {
         if (args['config']) {
-            console.error('No such file:', args['config']);
+            console.error('No such file:', config_path);
             process.exit(1);
         }
         // Otherwise, failure to read $HOME/.config/slack-keep-presence is not


### PR DESCRIPTION
I noticed that the -c option didn't work with my config file, and upon debugging found it was always expecting a relative path.  Patch just skips the joining of current working directory for paths starting with '/', and changes the error message to use the resolved path name rather than the config argument to make it obvious what happened if it errors with the filename still.